### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -62,7 +62,7 @@ jobs:
         if: matrix.platform == 'macos-latest'
         run: |
           echo "APPLE_ID=${{ secrets.NOTARIZATION_APPLE_ID }}" >> $GITHUB_ENV
-          echo "APPLE_ID_PASSWORD=${{ secrets.NOTARIZATION_APPLE_ID_PASSWORD }}" >> $GITHUB_ENV
+          echo "APPLE_PASSWORD=${{ secrets.NOTARIZATION_APPLE_ID_PASSWORD }}" >> $GITHUB_ENV
           echo "APPLE_TEAM_ID=${{ secrets.NOTARIZATION_APPLE_TEAM_ID }}" >> $GITHUB_ENV
 
       - name: install frontend dependencies

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyring-demo"
-version = "1.0.0"
+version = "1.0.1"
 description = "Rust back-end for keyring Tauri app"
 authors = ["Daniel Brotsky <dev@brotsky.com>"]
 edition = "2021"
@@ -15,7 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 hex = "0.4.3"
 indexmap = "2.14.0"
-keyring = "4.0.1"
+keyring = { version="4.1.0", no-default-features = true, features = ["cli"] }
 keyring-core = "1.0.0"
 ndk-context = "0.1.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "keyring-demo",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"identifier": "com.brotsky.keyring-demo",
 	"build": {
 		"beforeDevCommand": "npm run dev",
@@ -37,10 +37,10 @@
 		},
 		"iOS": {
 			"developmentTeam": "85H73V9R3F",
-			"bundleVersion": "1.0.10"
+			"bundleVersion": "1.0.11"
 		},
 		"macOS": {
-			"bundleVersion": "1.0.10",
+			"bundleVersion": "1.0.11",
 			"minimumSystemVersion": "12.0",
 			"signingIdentity": "B2E9FBC951B31D5FD29267A410264E71C905703F",
 			"entitlements": "./Entitlements.plist",
@@ -49,7 +49,7 @@
 			}
 		},
 		"windows": {
-			"wix": { "version": "1.0.0.9" }
+			"wix": { "version": "1.0.1.1" }
 		}
 	}
 }


### PR DESCRIPTION
Updated to use newest release of keyring (v4.1.0). There are no functional changes.